### PR TITLE
修复反连平台bug；增加配置自己搭建的Eye.sh平台的选项。

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -52,6 +52,7 @@ type Ceye struct {
 }
 
 type Eye struct {
+	Host   string `yaml:"host"`
 	Token  string `yaml:"token"`
 	Domain string `yaml:"domain"`
 }
@@ -77,6 +78,8 @@ func NewConfig() (*Config, error) {
 		reverse := c.Reverse
 		reverse.Ceye.ApiKey = ""
 		reverse.Ceye.Domain = ""
+		reverse.Eye.Host = "eyes.sh"
+
 		reverse.Jndi.JndiAddress = ""
 		reverse.Jndi.LdapPort = ""
 		reverse.Jndi.ApiPort = ""

--- a/v2/pkg/config/options.go
+++ b/v2/pkg/config/options.go
@@ -24,6 +24,7 @@ import (
 var (
 	ReverseCeyeApiKey string
 	ReverseCeyeDomain string
+	ReverseEyeHost    string
 	ReverseEyeToken   string
 	ReverseEyeDomain  string
 	ReverseJndi       string
@@ -368,6 +369,7 @@ func (opt *Options) VerifyOptions() error {
 		ReverseCeyeApiKey = opt.Config.Reverse.Ceye.ApiKey
 		ReverseCeyeDomain = opt.Config.Reverse.Ceye.Domain
 
+		ReverseEyeHost = opt.Config.Reverse.Eye.Host
 		ReverseEyeDomain = opt.Config.Reverse.Eye.Domain
 		ReverseEyeToken = opt.Config.Reverse.Eye.Token
 

--- a/v2/pkg/runner/celprogram.go
+++ b/v2/pkg/runner/celprogram.go
@@ -595,9 +595,9 @@ func reverseCheck(r *proto.Reverse, timeout int64) bool {
 
 	urlStr := ""
 	sub := strings.Split(r.Domain, ".")[0]
-	if config.ReverseCeyeLive {
+	if config.ReverseEyeShLive {
 		domain := strings.Split(r.Domain, ".")[1]
-		urlStr = fmt.Sprintf("http://eyes.sh/api/dns/%s/%s/?token=%s", domain, sub, config.ReverseEyeToken)
+		urlStr = fmt.Sprintf("http://%s/api/dns/%s/%s/?token=%s", config.ReverseEyeHost, domain, sub, config.ReverseEyeToken)
 		resp, err := retryhttpclient.ReverseGet(urlStr)
 		if err != nil {
 			return false
@@ -606,7 +606,7 @@ func reverseCheck(r *proto.Reverse, timeout int64) bool {
 		if bytes.Contains(resp, []byte("True")) {
 			return true
 		}
-	} else if config.ReverseEyeShLive {
+	} else if config.ReverseCeyeLive {
 		urlStr = fmt.Sprintf("http://api.ceye.io/v1/records?token=%s&type=dns&filter=%s", config.ReverseCeyeApiKey, sub)
 		resp, err := retryhttpclient.ReverseGet(urlStr)
 		// fmt.Println(string(resp))

--- a/v2/pkg/runner/engine.go
+++ b/v2/pkg/runner/engine.go
@@ -261,7 +261,7 @@ func EyeTest() bool {
 		domain = config.ReverseEyeDomain[:index]
 	}
 
-	url := fmt.Sprintf("http://eyes.sh/api/dns/%s/test/?token=%s", domain, config.ReverseEyeToken)
+	url := fmt.Sprintf("http://%s/api/dns/%s/test/?token=%s", config.ReverseEyeHost, domain, config.ReverseEyeToken)
 	resp, _, err := retryhttpclient.Get(url)
 	if err != nil {
 		return false


### PR DESCRIPTION
## 1. 原来的DNSLog逻辑存在bug

在v2\pkg\runner\celprogram.go的dnslog判断处，原来的代码存在逻辑问题：

![image](https://github.com/zan8in/afrog/assets/53418634/22ef2615-ae55-4fe2-afac-fbc01e884428)


可以看到，此处判断如果Ceye存活，反而走了EyeSh的DNSLog判断流程；如果EyeSh存活，反而进行了Ceye的DNSLog判断流程，所以存在逻辑错误。我对此处进行了修正。

## 2.增加在自己的VPS上配置的EyeSh选项

在我进行POC批量验证的时候，发现DNSLog平台收到了大量的响应，但是POC验证成功的目标却少很多。经过测试，判断是网络原因导致的。而如果能使用在自己的VPS上搭建DNSLog平台，这种情况应该会有很大的改善。

所以我对代码进行了修改，来适配在个人VPS上搭建的EyeSh。

修改后的配置文件需要填入Host参数（ip:port、domain:port等形式），host填写eyes.sh时（默认生成即填写eyes.sh)，将完全适配官方的DnsLog：

![image](https://github.com/zan8in/afrog/assets/53418634/577beb7e-1339-40c5-91fb-d5e738b38fef)


测试效果，在自己搭建的DnsLog平台上非常流畅：

![image](https://github.com/zan8in/afrog/assets/53418634/ac2c6a54-82ac-455e-9c7f-afdf76e4270c)
![image](https://github.com/zan8in/afrog/assets/53418634/39c9de63-c1d6-4b46-a884-eb2df460d517)
