### PR TITLE
yaml模板规则，在type中增加https选项，区别于http选项，从而支持某些复杂情况下的poc

### DIFF
--- a/pkg/poc/poc.go
+++ b/pkg/poc/poc.go
@@ -96,11 +96,12 @@ type RuleRequest struct {
 }
 
 const (
-	HTTP_Type = "http"
-	TCP_Type  = "tcp"
-	UDP_Type  = "udp"
-	SSL_Type  = "ssl"
-	GO_Type   = "go"
+	HTTP_Type  = "http"
+	HTTPS_Type = "https"
+	TCP_Type   = "tcp"
+	UDP_Type   = "udp"
+	SSL_Type   = "ssl"
+	GO_Type    = "go"
 )
 
 // 以下开始是 信息部分
@@ -319,7 +320,7 @@ func (poc *Poc) Reset() {
 func (poc *Poc) IsHTTPType() bool {
 	for _, rule := range poc.Rules {
 		reqType := rule.Value.Request.Type
-		if len(reqType) == 0 || reqType == HTTP_Type {
+		if len(reqType) == 0 || reqType == HTTP_Type || reqType == HTTPS_Type {
 			return true
 		}
 	}


### PR DESCRIPTION
某些复杂情况的poc，需要向一个ip的不同端口发poc，这些端口的web服务有些是http的，有些是https的。
比如海康综合安防，有些漏洞的poc需要向默认8001端口的http协议的运行管理中心发包，文件写到443端口的https协议的web服务中。

POC：

![image](https://github.com/user-attachments/assets/f3929322-2238-4a82-aebd-acf39bb8f420)

修改前发包，无法自定义http、https：

![image](https://github.com/user-attachments/assets/53e2ba08-21a5-48af-bd26-fadcb932cc15)

修改后发包，可以自定义http、https：

![image](https://github.com/user-attachments/assets/9f427015-2247-410c-ae01-bc9cb7026bf9)
![image](https://github.com/user-attachments/assets/1af3f6f1-761a-4751-81b2-3775e6f3ee98)

