### PR TITLE
update GoReleaser configurations

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,9 +22,10 @@ builds:
       - -w
 
 archives:
-  - format: zip
+  - formats:
+    - zip
     id: afrog
-    builds: [afrog]
+    ids: [afrog]
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}_{{ .Arch }}'
 
 checksum:


### PR DESCRIPTION
# Description
Hi, cool repo. 🙌 
This small PR updates the GoReleaser configuration to resolve the following warnings, which you can find in the [CI logs](https://github.com/zan8in/afrog/actions/runs/16989023864/job/48163973077#step:4:24): 
```
DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
DEPRECATED: archives.builds should not be used anymore, check https://goreleaser.com/deprecations#archivesbuilds for more info
```