### PR TITLE
add wecom webhook function

### DIFF
--- a/cmd/afrog/main.go
+++ b/cmd/afrog/main.go
@@ -106,6 +106,9 @@ func main() {
 			if options.Dingtalk {
 				go r.Ding.SendMarkDownMessageBySlice("From afrog vulnerability Notice", r.Ding.MarkdownText(result.PocInfo.Id, result.PocInfo.Info.Severity, result.FullTarget))
 			}
+			if options.Wecom {
+				go r.Wecom.SendVulMessage(result, r.Wecom.Markdown)
+			}
 
 			if !options.DisableOutputHtml {
 				r.Report.SetResult(result)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/cel-go v0.9.0
 	github.com/gookit/color v1.5.0
+	github.com/gorilla/mux v1.8.1
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/karrick/godirwalk v1.16.1
 	github.com/logoove/sqlite v1.15.3
@@ -19,6 +20,7 @@ require (
 	github.com/remeh/sizedwaitgroup v1.0.0
 	github.com/rs/xid v1.5.0
 	github.com/spaolacci/murmur3 v1.1.0
+	github.com/vimsucks/wxwork-bot-go v1.0.0
 	github.com/zan8in/fileutil v0.0.0-20220917063910-ce47dcc0cfa9
 	github.com/zan8in/goflags v0.0.0-20230204144650-0745934af58a
 	github.com/zan8in/gologger v0.0.0-20220917062627-c34a83c0a373
@@ -56,7 +58,6 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
-	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gosuri/uilive v0.0.4 // indirect
 	github.com/gosuri/uiprogress v0.0.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1200,6 +1200,8 @@ github.com/valyala/fasthttp v1.6.0/go.mod h1:FstJa9V+Pj9vQ7OJie2qMHdwemEDaDiSdBn
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
+github.com/vimsucks/wxwork-bot-go v1.0.0 h1:e6iNwNVTUkLZ7Ee+LzIyCOAxNkG8LODWvTMryjynS2M=
+github.com/vimsucks/wxwork-bot-go v1.0.0/go.mod h1:brn5UkCRa+oqXYsvyO0Mz5JsfU2vlOWUndlvYILUacw=
 github.com/weppos/publicsuffix-go v0.12.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/weppos/publicsuffix-go v0.13.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/weppos/publicsuffix-go v0.30.0 h1:QHPZ2GRu/YE7cvejH9iyavPOkVCB4dNxp2ZvtT+vQLY=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,8 +32,15 @@ type ConfigHttp struct {
 
 type Webhook struct {
 	Dingtalk Dingtalk `yaml:"dingtalk"`
+	Wecom    Wecom    `yaml:"wecom"`
 }
-
+type Wecom struct {
+	Tokens    []string `yaml:"tokens"`
+	AtMobiles []string `yaml:"at_mobiles"`
+	AtAll     bool     `yaml:"at_all"`
+	Range     string   `yaml:"range"`
+	Markdown  bool     `yaml:"markdown"`
+}
 type Dingtalk struct {
 	Tokens    []string `yaml:"tokens"`
 	AtMobiles []string `yaml:"at_mobiles"`
@@ -146,6 +153,11 @@ func NewConfig(configFile string) (*Config, error) {
 		webhook.Dingtalk.AtMobiles = []string{""}
 		webhook.Dingtalk.AtAll = false
 		webhook.Dingtalk.Range = "high,critical"
+		webhook.Wecom.Tokens = []string{""}
+		webhook.Wecom.AtMobiles = []string{""}
+		webhook.Wecom.AtAll = false
+		webhook.Wecom.Range = "high,critical"
+		webhook.Wecom.Markdown = true
 		c.Webhook = webhook
 
 		cyberspace := c.Cyberspace

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -17,6 +17,7 @@ import (
 	"github.com/zan8in/afrog/v3/pkg/validator"
 	"github.com/zan8in/afrog/v3/pkg/web"
 	"github.com/zan8in/afrog/v3/pkg/webhook/dingtalk"
+	"github.com/zan8in/afrog/v3/pkg/webhook/wecom"
 	"github.com/zan8in/afrog/v3/pocs"
 	"github.com/zan8in/goflags"
 	"github.com/zan8in/gologger"
@@ -152,6 +153,9 @@ type Options struct {
 	// webhook
 	Dingtalk bool
 
+	// webhook wecom
+	Wecom bool
+
 	// resume
 	Resume string
 
@@ -271,6 +275,7 @@ func NewOptions() (*Options, error) {
 
 	flagSet.CreateGroup("webhook", "Webhook",
 		flagSet.BoolVar(&options.Dingtalk, "dingtalk", false, "Start a dingtalk webhook."),
+		flagSet.BoolVar(&options.Wecom, "wecom", false, "Start a wecom webhook."),
 	)
 
 	flagSet.CreateGroup("configurations", "Configurations",
@@ -326,7 +331,11 @@ func (opt *Options) VerifyOptions() error {
 			return fmt.Errorf("Dingtalk webhook token is required")
 		}
 	}
-
+	if opt.Wecom {
+		if wecom.IsTokensEmpty(opt.Config.Webhook.Wecom.Tokens) {
+			return fmt.Errorf("Wecom webhook token is required")
+		}
+	}
 	if opt.Web {
 		serveraddress := ":16868"
 		if config.ServerAddress != "" {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zan8in/afrog/v3/pkg/result"
 	"github.com/zan8in/afrog/v3/pkg/utils"
 	"github.com/zan8in/afrog/v3/pkg/webhook/dingtalk"
+	"github.com/zan8in/afrog/v3/pkg/webhook/wecom"
 	"github.com/zan8in/afrog/v3/pocs"
 	"github.com/zan8in/oobadapter/pkg/oobadapter"
 )
@@ -35,6 +36,7 @@ type Runner struct {
 	PocsEmbedYaml utils.StringSlice
 	engine        *Engine
 	Ding          *dingtalk.Dingtalk
+	Wecom         *wecom.Wecom
 	ScanProgress  *ScanProgress
 	Cyberspace    *cyberspace.Cyberspace
 	// OOB           *oobadapter.OOBAdapter
@@ -62,6 +64,14 @@ func NewRunner(options *config.Options) (*Runner, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+	if options.Wecom {
+		runner.Wecom, err = wecom.New(
+			options.Config.Webhook.Wecom.Tokens,
+			options.Config.Webhook.Wecom.AtMobiles,
+			options.Config.Webhook.Wecom.Range,
+			options.Config.Webhook.Wecom.AtAll,
+			options.Config.Webhook.Wecom.Markdown)
 	}
 
 	// cyberspace

--- a/pkg/webhook/wecom/wecom.go
+++ b/pkg/webhook/wecom/wecom.go
@@ -1,0 +1,124 @@
+package wecom
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"strings"
+
+	wxworkbot "github.com/vimsucks/wxwork-bot-go"
+	"github.com/zan8in/afrog/v3/pkg/result"
+	timeutil "github.com/zan8in/pins/time"
+)
+
+type Wecom struct {
+	Tokens    []string
+	Range     string
+	AtMobiles []string
+	AtAll     bool
+	Markdown  bool
+}
+
+func New(tokens, atMobiles []string, rang string, atAll bool, markdown bool) (*Wecom, error) {
+	if len(tokens) == 0 {
+		return nil, errors.New("tokens can not be empty")
+	}
+	return &Wecom{
+		Tokens:    tokens,
+		AtMobiles: atMobiles,
+		AtAll:     atAll,
+		Range:     rang,
+		Markdown:  markdown,
+	}, nil
+}
+func (w *Wecom) SendVulMessage(result *result.Result, markdown bool) error {
+	if result == nil {
+		return nil
+	}
+	content := []string{}
+	if w.AtAll {
+		w.AtMobiles = append(w.AtMobiles, "@all")
+	}
+	if !markdown {
+		content = w.makeText(result.PocInfo.Id, result.PocInfo.Info.Severity, result.FullTarget)
+	} else {
+		content = w.markdownText(result.PocInfo.Id, result.PocInfo.Info.Severity, result.FullTarget)
+	}
+	if content == nil {
+		return nil
+	}
+	if w.Markdown {
+		content = append(content, "<@all>")
+	}
+	return w.sendMessage(content, markdown)
+}
+func (w *Wecom) sendMessage(content []string, markdown bool) error {
+	bot := wxworkbot.New(w.Tokens[rand.Intn(len(w.Tokens))])
+	if !markdown {
+		text := wxworkbot.Text{
+			Content:             strings.Join(content, "\n"),
+			MentionedMobileList: w.AtMobiles,
+		}
+		err := bot.Send(text)
+		if err != nil {
+			return err
+		}
+	} else {
+		markdownText := wxworkbot.Markdown{Content: strings.Join(content, "\n")}
+		err := bot.Send(markdownText)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func (w *Wecom) markdownText(id, severity, url string) []string {
+	if !strings.Contains(w.Range, strings.ToLower(severity)) {
+		return nil
+	}
+	return []string{
+		fmt.Sprintf("##### %s %s", id, w.severity(severity)),
+		"---",
+		fmt.Sprintf("%s", url),
+		fmt.Sprintf("<font color=GRAY>%s\tfr.afrog</font>", timeutil.Format(timeutil.FormatShortDateTime)),
+	}
+}
+func (w *Wecom) makeText(id, severity, url string) []string {
+	if !strings.Contains(w.Range, strings.ToLower(severity)) {
+		return nil
+	}
+	return []string{
+		fmt.Sprintf("Time: %s", timeutil.Format(timeutil.FormatShortDateTime)),
+		fmt.Sprintf("Vuln Name: %s\nVunln Level:%s", id, severity),
+		fmt.Sprintf("Target: %s", url),
+	}
+}
+func (w *Wecom) severity(s string) string {
+	r := "warning"
+	if strings.TrimSpace(s) == "info" {
+		r = "info"
+	}
+	return fmt.Sprintf("<font color='%s'>%s</font>", r, s)
+}
+func IsTokensEmpty(tokens []string) bool {
+	if len(tokens) == 0 {
+		return true
+	}
+	for _, token := range tokens {
+		if len(token) > 0 {
+			return false
+		}
+	}
+	return true
+}
+func (w *Wecom) isAtMobilesEmpty() bool {
+	if len(w.AtMobiles) == 0 {
+		return true
+	}
+	for _, mobile := range w.AtMobiles {
+		if len(mobile) > 0 {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
### **使用参数-wecom开启**
<img width="2670" height="1206" alt="image" src="https://github.com/user-attachments/assets/28bbd9b4-e535-4ca0-9eb5-d349386b2024" />

### **在配置文件中设置详细的发送细节**
<img width="2048" height="1510" alt="image" src="https://github.com/user-attachments/assets/484d5192-2402-4bab-8300-31604f03d70a" />

### **字段解释**
| 字段名 | 含义  | 默认值                  |
|--------|-------|-----------------------|
| tokens  | 获取到的企业微信webhook key,可配置多个 | 空 |
| at_mobiles   | 具体需要@的人员电话或者user_id | 空       |
| at_all  | 是否@全体成员 | false       |
| range   | 需要发送的威胁程度 | high,critical       |
| markdown  | 使用markdown格式发送 | true       |


@zan8in 
