### PR TITLE
fix: apply severity filter to output stage for console and report res…

### DIFF
--- a/afrog.go
+++ b/afrog.go
@@ -176,14 +176,14 @@ type SDKOptions struct {
 	Headers []string
 
 	// ========== OOB配置 ==========
-	EnableOOB      bool   // 是否启用OOB检测 (默认: false)
-	OOB            string // OOB适配器类型: ceyeio, dnslogcn, alphalog, xray, revsuit
-	OOBKey         string // OOB API密钥
-	OOBDomain      string // OOB域名
-	OOBApiUrl      string // OOB API地址
-	OOBHttpUrl     string // OOB HTTP地址
-	OOBRateLimit   int
-	OOBConcurrency int
+	EnableOOB          bool   // 是否启用OOB检测 (默认: false)
+	OOB                string // OOB适配器类型: ceyeio, dnslogcn, alphalog, xray, revsuit
+	OOBKey             string // OOB API密钥
+	OOBDomain          string // OOB域名
+	OOBApiUrl          string // OOB API地址
+	OOBHttpUrl         string // OOB HTTP地址
+	OOBRateLimit       int
+	OOBConcurrency     int
 	OOBFinalizeTimeout int
 
 	// ========== 输出配置 ==========
@@ -626,6 +626,15 @@ func (s *SDKScanner) run() error {
 		}
 
 		if r.IsVul {
+			if s.options.Severity != "" {
+				sev := strings.TrimSpace(r.PocInfo.Info.Severity)
+				if sev == "" {
+					sev = "info"
+				}
+				if !s.matchesSeverity(sev) {
+					return
+				}
+			}
 			s.mu.Lock()
 			s.results = append(s.results, r)
 			atomic.AddInt32(&s.stats.FoundVulns, 1)
@@ -906,6 +915,18 @@ func (s *SDKScanner) IsPaused() bool {
 
 func (s *SDKScanner) IsStopping() bool {
 	return s.options.VulnerabilityScannerBreakpoint
+}
+
+func (s *SDKScanner) matchesSeverity(sev string) bool {
+	if s.options.Severity == "" {
+		return true
+	}
+	for _, keyword := range strings.Split(s.options.Severity, ",") {
+		if strings.EqualFold(sev, strings.TrimSpace(keyword)) {
+			return true
+		}
+	}
+	return false
 }
 
 // SetProxy 动态设置代理

--- a/cmd/afrog/main.go
+++ b/cmd/afrog/main.go
@@ -273,6 +273,13 @@ func main() {
 				rst.FullTarget = rst.Target
 			}
 
+			if len(options.Severity) > 0 {
+				sev := strings.ToLower(strings.TrimSpace(rst.PocInfo.Info.Severity))
+				if !stringsInSlice(sev, options.SeverityKeywords) {
+					continue
+				}
+			}
+
 			lock.Lock()
 			fmt.Fprint(os.Stderr, "\r\033[2K\r")
 
@@ -364,6 +371,13 @@ func main() {
 		}
 
 		if result.IsVul {
+			if len(options.Severity) > 0 {
+				sev := strings.ToLower(strings.TrimSpace(result.PocInfo.Info.Severity))
+				if !stringsInSlice(sev, options.SeverityKeywords) {
+					return
+				}
+			}
+
 			lock.Lock()
 			fmt.Fprint(os.Stderr, "\r\033[2K\r")
 
@@ -521,4 +535,13 @@ func expandTildePath(v string) string {
 		return filepath.Join(home, strings.TrimPrefix(s, "~"+sep))
 	}
 	return filepath.Clean(s)
+}
+
+func stringsInSlice(target string, slice []string) bool {
+	for _, s := range slice {
+		if strings.EqualFold(target, s) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -205,13 +205,13 @@ type Options struct {
 	QueryCount int
 
 	// oobadapter, eg: `-oob ceyeio` or `-oob dnslogcn` or `-oob alphalog`
-	OOB             string
-	OOBKey          string
-	OOBDomain       string
-	OOBHttpUrl      string
-	OOBApiUrl       string
-	OOBPollInterval int
-	OOBHitRetention int
+	OOB                string
+	OOBKey             string
+	OOBDomain          string
+	OOBHttpUrl         string
+	OOBApiUrl          string
+	OOBPollInterval    int
+	OOBHitRetention    int
 	OOBFinalizeTimeout int
 
 	// SDK模式标志，用于控制OOB检测行为
@@ -588,6 +588,8 @@ func (opt *Options) VerifyOptions() error {
 
 	if !(len(opt.Target) > 0 || len(opt.TargetsFile) > 0 || (len(opt.Cyberspace) > 0 && len(opt.Query) > 0)) {
 	}
+
+	opt.SetSeverityKeyword()
 
 	return nil
 }


### PR DESCRIPTION
# fix: 将严重性过滤器应用到输出阶段

fix #206

## 变更说明

`-S`（severity）参数此前仅在 POC 加载阶段生效，输出阶段（控制台和报告）未做过滤。本次修改在以下位置补充了严重性过滤：

- `cmd/afrog/main.go` — CLI 模式控制台输出
- `afrog.go` — SDK 模式结果收集
- `pkg/config/options.go` — 选项初始化

## 测试

| 环境 | 值 |
|------|-----|
| 测试目标 | `http://127.0.0.1:8848/` (Nacos 1.4.0) |
| 编译环境 | Go 1.26.2 windows/amd64 |
| afrog Core | 3.5.2 / POC 0.5.28 |

```bash
PS C:\Users\username\GolandProjects\afrog> .\afrog.exe -t http://127.0.0.1:8848/ -S critical

Afrog/3.5.2 | Security Toolkit | Lightweight, Fast, and Direct to the Flaw.
════════════════════════════════════════════════════════
[✓] Core:  3.5.2
[✓] POC:   0.5.28
[✓] Cur:   0/pocs https://t.zsxq.com/lV66x
[✖] OOB:   ceyeio (Not configured)
════════════════════════════════════════════════════════
[INF] HOST-DISC | skipped   | -ps not enabled
[INF] PORT-SCAN | skipped   | -ps not enabled
[INF] VULN-SCAN | started   | targets=1 pocs=626 tasks=600
001 04-26 16:10:35 nacos-authentication-bypass CRITICAL http://127.0.0.1:8848/nacos/v1/auth/users?pageNo=1&pageSize=10&accessToken=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJuYWNvcyIsImV4cCI6OTk5OTk5OTk5OTl9.-isk56R8NfioHVYmpj4oz92nUteNBCN3HRd0-Hfk76g
002 04-26 16:10:35 nacos-core-auth-enabled-bypass CRITICAL http://127.0.0.1:8848/nacos/v1/auth/users?pageNo=1&pageSize=9&search=accurate&accessToken
003 04-26 16:10:35 nacos-token-create-user CRITICAL http://127.0.0.1:8848/nacos/v1/auth/users?username=vpqfuz
[━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━] 100% (600/600), 30s oobf=0/0 skipped
[INF] VULN-SCAN | completed | tasks=600/600 found=3 duration=30s
```
<img width="3321" height="575" alt="image" src="https://github.com/user-attachments/assets/1916f1eb-e19d-492a-a193-884626a1afea" />

```bash
PS C:\Users\username\GolandProjects\afrog> .\afrog.exe -t http://127.0.0.1:8848/ -S high

Afrog/3.5.2 | Security Toolkit | Lightweight, Fast, and Direct to the Flaw.
════════════════════════════════════════════════════════
[✓] Core:  3.5.2
[✓] POC:   0.5.28
[✓] Cur:   0/pocs https://t.zsxq.com/lV66x
[✖] OOB:   ceyeio (Not configured)
════════════════════════════════════════════════════════
[INF] HOST-DISC | skipped   | -ps not enabled
[INF] PORT-SCAN | skipped   | -ps not enabled
[INF] VULN-SCAN | started   | targets=1 pocs=894 tasks=870
001 04-26 16:11:13 nacos-config-server-sql-inject HIGH http://127.0.0.1:8848/nacos/v1/cs/ops/derby?sql=select%20*%20from%20users%20
002 04-26 16:11:13 nacos-secret-default-key-unauth HIGH http://127.0.0.1:8848/nacos/v1/auth/users?accessToken=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJuYWNvcyIsImV4cCI6MTY5ODg5NDcyN30.feetKmWoPnMkAebjkNnyuKo6c21_hzTgu0dfNqbdpZQ&pageNo=1&pageSize=9
003 04-26 16:11:13 nacos-severidentity-bypass HIGH http://127.0.0.1:8848/nacos/v1/auth/users?pageNo=1&pageSize=9&search=accurate&accessToken
004 04-26 16:11:13 nacos-user-list-unauthorized HIGH http://127.0.0.1:8848/nacos/v1/auth/users?pageNo=1&pageSize=9
005 04-26 16:11:13 nacos-create-user-unauthorized HIGH http://127.0.0.1:8848/nacos/v1/auth/users?username=cgofomyg
[━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━] 100% (870/870), 5s oobf=0/0 skipped
[INF] VULN-SCAN | completed | tasks=870/870 found=5 duration=5s
```
<img width="3788" height="797" alt="image" src="https://github.com/user-attachments/assets/ad89581b-ada4-4570-99b0-d773a03ec70a" />

```bash
PS C:\Users\username\GolandProjects\afrog> .\afrog.exe -t http://127.0.0.1:8848/ -S high,critical

Afrog/3.5.2 | Security Toolkit | Lightweight, Fast, and Direct to the Flaw.
════════════════════════════════════════════════════════
[✓] Core:  3.5.2
[✓] POC:   0.5.28
[✓] Cur:   0/pocs https://t.zsxq.com/lV66x
[✖] OOB:   ceyeio (Not configured)
════════════════════════════════════════════════════════
[INF] HOST-DISC | skipped   | -ps not enabled
[INF] PORT-SCAN | skipped   | -ps not enabled
[INF] VULN-SCAN | started   | targets=1 pocs=1492 tasks=1461
001 04-26 16:12:27 nacos-config-server-sql-inject HIGH http://127.0.0.1:8848/nacos/v1/cs/ops/derby?sql=select%20*%20from%20users%20
002 04-26 16:12:27 nacos-secret-default-key-unauth HIGH http://127.0.0.1:8848/nacos/v1/auth/users?accessToken=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJuYWNvcyIsImV4cCI6MTY5ODg5NDcyN30.feetKmWoPnMkAebjkNnyuKo6c21_hzTgu0dfNqbdpZQ&pageNo=1&pageSize=9
003 04-26 16:12:27 nacos-severidentity-bypass HIGH http://127.0.0.1:8848/nacos/v1/auth/users?pageNo=1&pageSize=9&search=accurate&accessToken
004 04-26 16:12:27 nacos-user-list-unauthorized HIGH http://127.0.0.1:8848/nacos/v1/auth/users?pageNo=1&pageSize=9
005 04-26 16:12:27 nacos-create-user-unauthorized HIGH http://127.0.0.1:8848/nacos/v1/auth/users?username=uklzfdvl
006 04-26 16:12:32 nacos-authentication-bypass CRITICAL http://127.0.0.1:8848/nacos/v1/auth/users?pageNo=1&pageSize=10&accessToken=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJuYWNvcyIsImV4cCI6OTk5OTk5OTk5OTl9.-isk56R8NfioHVYmpj4oz92nUteNBCN3HRd0-Hfk76g
007 04-26 16:12:32 nacos-core-auth-enabled-bypass CRITICAL http://127.0.0.1:8848/nacos/v1/auth/users?pageNo=1&pageSize=9&search=accurate&accessToken
008 04-26 16:12:32 nacos-token-create-user CRITICAL http://127.0.0.1:8848/nacos/v1/auth/users?username=jkgmtm
[━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━] 100% (1461/1461), 35s oobf=0/0 skipped
[INF] VULN-SCAN | completed | tasks=1461/1461 found=8 duration=35s
```
<img width="3805" height="853" alt="image" src="https://github.com/user-attachments/assets/616c29be-17b6-4cca-ab84-8d317c8e688e" />

### 结果

```
无 -S 参数:  tasks=1662/1662  found=10  duration=37s
-S critical,high,medium:  tasks=2/2  found=0  duration=69s
```

INFO 级别的 `nacos-detect` 在无过滤时被检出，加 `-s critical,high,medium` 后正确过滤不显示。
