### PR TITLE
fix: correct typo falied to failed in error messages

### DIFF
--- a/pkg/runner/checker.go
+++ b/pkg/runner/checker.go
@@ -725,7 +725,7 @@ func (c *Checker) checkURL(target string) (string, error) {
 		} else if shouldCountHostError(err) {
 			c.Options.Targets.UpdateNum(target, 1)
 		}
-		return target, fmt.Errorf("%s check protocol falied", target)
+		return target, fmt.Errorf("%s check protocol failed", target)
 	}
 
 	// if target is url more than zero, then check protocol against

--- a/pkg/runner/monitor.go
+++ b/pkg/runner/monitor.go
@@ -110,7 +110,7 @@ func (r *Runner) checkURL(target string) (string, error) {
 		} else if shouldCountHostError(err) {
 			r.options.Targets.UpdateNum(target, 1)
 		}
-		return target, fmt.Errorf("%s check protocol falied", target)
+		return target, fmt.Errorf("%s check protocol failed", target)
 	}
 
 	// if target is url more than zero, then check protocol against


### PR DESCRIPTION
## Summary
Corrected typo `falied` → `failed` in two Go files.

## Files Changed
- `pkg/runner/monitor.go` - error message fix
- `pkg/runner/checker.go` - error message fix

## Testing
`go build ./...`
`go vet ./...`
`go test ./...`